### PR TITLE
User Fines & Fees

### DIFF
--- a/src/user-fee.js
+++ b/src/user-fee.js
@@ -3,7 +3,7 @@ const BaseResource = require('./base-resource')
 class UserFee extends BaseResource {}
 
 UserFee.config = {
-  path: (userID, feeID) => `/users/${userID}/fee/${feeID}`,
+  path: (userID, feeID) => `/users/${userID}/fees/${feeID}`,
   id: 'id'
 }
 

--- a/src/user-fee.js
+++ b/src/user-fee.js
@@ -1,0 +1,10 @@
+const BaseResource = require('./base-resource')
+
+class UserFee extends BaseResource {}
+
+UserFee.config = {
+  path: (userID, feeID) => `/users/${userID}/fee/${feeID}`,
+  id: 'id'
+}
+
+module.exports = UserFee

--- a/src/user.js
+++ b/src/user.js
@@ -1,6 +1,7 @@
 const BaseResource = require('./base-resource')
 const UserLoan = require('./user-loan')
 const UserRequest = require('./user-request')
+const UserFee = require('./user-fee')
 
 class User extends BaseResource {
   loans () {
@@ -11,6 +12,10 @@ class User extends BaseResource {
     return this._getSubResourceMap('requests')
   }
 
+  fees () {
+    return this._getSubResourceMap('fees')
+  }
+
   getLoan (loanID) {
     return this._getSubResource('loans', loanID)
   }
@@ -19,12 +24,20 @@ class User extends BaseResource {
     return this._getSubResource('requests', requestID)
   }
 
+  getFee (feeID) {
+    return this._getSubResource('fees', feeID)
+  }
+
   getLoanFromApi (loanID) {
     return this._getSubResourceFromApi('loans', loanID)
   }
 
   getRequestFromApi (requestID) {
     return this._getSubResourceFromApi('requests', requestID)
+  }
+
+  getFeeFromApi (feeID) {
+    return this._getSubResourceFromApi('fees', feeID)
   }
 }
 
@@ -44,6 +57,12 @@ User.children = {
     almaResourceID: 'request_id',
     Class: UserRequest,
     path: (userID) => `/users/${userID}/requests`
+  },
+  fees: {
+    almaResourceName: 'fee',
+    almaResourceID: 'id',
+    Class: UserFee,
+    path: (userID) => `/users/${userID}/fees`
   }
 }
 

--- a/test/call-tests.js
+++ b/test/call-tests.js
@@ -320,4 +320,41 @@ describe('api call tests', () => {
         })
     })
   })
+
+  describe('path: /users/<userID>/fees/<feeID>', () => {
+    it('should call the api with the correct path', () => {
+      const testUserID = uuid()
+      const testFeeID = uuid()
+
+      const axiosStub = sandbox.stub(almaApi.api, 'get')
+      axiosStub.resolves({ request_id: testFeeID })
+
+      return almaApi.users.for(testUserID).getFee(testFeeID)
+        .then(() => {
+          axiosStub.should.have.been.calledWith('/users/' + testUserID + '/fees/' + testFeeID)
+        })
+    })
+
+    it('should resolve with a Request instance', () => {
+      const testUserID = uuid()
+      const testFeeID = uuid()
+
+      const axiosStub = sandbox.stub(almaApi.api, 'get')
+      axiosStub.resolves({ id: testFeeID })
+
+      return almaApi.users.for(testUserID).getFee(testFeeID)
+        .then((res) => {
+          res.should.be.an.instanceOf(UserFee)
+          res.data.should.deep.equal({ id: testFeeID })
+          res.id.should.equal(testFeeID)
+        })
+    })
+
+    it('should handle an invalid loan ID', () => {
+      const axiosStub = sandbox.stub(almaApi.api, 'get')
+      axiosStub.rejects(new Error('Request failed with status code 500'))
+
+      return almaApi.users.for(uuid()).getFee(uuid()).should.eventually.be.rejectedWith('Request failed with status code 500')
+    })
+  })
 })

--- a/test/user-test.js
+++ b/test/user-test.js
@@ -304,6 +304,54 @@ describe('User class tests', () => {
         })
       })
     })
+
+    describe('getLoanFromApi method tests', () => {
+      describe('should call _getSubResourceFromApi', () => {
+        const testUserID = uuid()
+        const testUser = new User({ primary_id: testUserID })
+        const testLoanID = uuid()
+
+        const fromApiStub = sandbox.stub(testUser, '_getSubResourceFromApi')
+        fromApiStub.resolves()
+
+        return testUser.getLoanFromApi(testLoanID)
+          .then(() => {
+            fromApiStub.should.have.been.calledWith('loans', testLoanID)
+          })
+      })
+    })
+
+    describe('getRequestFromApi method tests', () => {
+      describe('should call _getSubResourceFromApi', () => {
+        const testUserID = uuid()
+        const testUser = new User({ primary_id: testUserID })
+        const testRequestID = uuid()
+
+        const fromApiStub = sandbox.stub(testUser, '_getSubResourceFromApi')
+        fromApiStub.resolves()
+
+        return testUser.getRequestFromApi(testRequestID)
+          .then(() => {
+            fromApiStub.should.have.been.calledWith('requests', testRequestID)
+          })
+      })
+    })
+
+    describe('getFeeFromApi method tests', () => {
+      describe('should call _getSubResourceFromApi', () => {
+        const testUserID = uuid()
+        const testUser = new User({ primary_id: testUserID })
+        const testFeeID = uuid()
+
+        const fromApiStub = sandbox.stub(testUser, '_getSubResourceFromApi')
+        fromApiStub.resolves()
+
+        return testUser.getFeeFromApi(testFeeID)
+          .then(() => {
+            fromApiStub.should.have.been.calledWith('fees', testFeeID)
+          })
+      })
+    })
   })
 
   describe('configuration tests', () => {


### PR DESCRIPTION
This adds a `UserFee` resource to the `User` class, with `fees` and `getFee` methods to get one or all User fees.

This provides support for the endpoints:
- `GET /users/<userID>/fees`
- `GET /users/<userID>/fees/<feeID>` 